### PR TITLE
Fixed issue where bash could not run tmpfile , (Text file busy)

### DIFF
--- a/lib/runners.py
+++ b/lib/runners.py
@@ -20,6 +20,7 @@ def _build_script(cmd_def):
         os.write(fh, '\n')
     os.write(fh, cmd_def['cmd'])
     os.write(fh, '\n')
+    os.close(fh)
 
     # ensure that the filepath is executable by the runner process, the default
     # tempfile is 0600 


### PR DESCRIPTION
:FlowRun results in following error 

/bin/bash: /tmp/tmplQje4n: /bin/bash: bad interpreter: Text file busy
shell returned 126

